### PR TITLE
feat: add global footer with nav links, branding and copyright

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import "./globals.css";
 import type { Metadata } from "next";
 import Navbar from "@/components/Navbar";
+import Footer from "@/components/Footer";
 
 export const metadata: Metadata = {
   title: "Parampara",
@@ -15,9 +16,10 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <body>
+      <body className="flex flex-col min-h-screen">
         <Navbar />
-        <main>{children}</main>
+        <main className="flex-1">{children}</main>
+        <Footer />
       </body>
     </html>
   );

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,0 +1,99 @@
+import Link from "next/link";
+
+const footerLinks = {
+  Platform: [
+    { label: "Home", href: "/" },
+    { label: "Instructors", href: "/instructors" },
+    { label: "About", href: "/about" },
+  ],
+  Legal: [
+    { label: "Terms of Service", href: "/terms" },
+    { label: "Privacy Policy", href: "/privacy" },
+  ],
+  Community: [
+    { label: "NSoC '26", href: "https://www.nsoc.in/projects", external: true },
+    {
+      label: "Contribute on GitHub",
+      href: "https://github.com/Mehren7/Parampara",
+      external: true,
+    },
+  ],
+};
+
+export default function Footer() {
+  return (
+    <footer className="w-full bg-gray-900 text-gray-300 mt-auto">
+      {/* Main Footer Content */}
+      <div className="max-w-6xl mx-auto px-4 py-12">
+        <div className="grid grid-cols-1 md:grid-cols-4 gap-10">
+          {/* Brand Column */}
+          <div className="md:col-span-1">
+            <Link href="/" className="flex items-center gap-2 mb-3">
+              <span className="text-xl">🌏</span>
+              <span className="text-white font-bold text-lg tracking-tight">
+                Parampara
+              </span>
+            </Link>
+            <p className="text-sm text-gray-400 leading-relaxed mb-4">
+              Connecting the global Indian diaspora with their cultural roots
+              while empowering women in India with sustainable income.
+            </p>
+          </div>
+
+          {/* Nav Link Columns */}
+          {Object.entries(footerLinks).map(([category, links]) => (
+            <div key={category}>
+              <h3 className="text-white font-semibold text-sm mb-4 uppercase tracking-wider">
+                {category}
+              </h3>
+              <ul className="flex flex-col gap-2.5">
+                {links.map((link) => (
+                  <li key={link.label}>
+                    {"external" in link && link.external ? (
+                      <a
+                        href={link.href}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-sm text-gray-400 hover:text-orange-400 transition-colors duration-200"
+                      >
+                        {link.label} ↗
+                      </a>
+                    ) : (
+                      <Link
+                        href={link.href}
+                        className="text-sm text-gray-400 hover:text-orange-400 transition-colors duration-200"
+                      >
+                        {link.label}
+                      </Link>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Bottom Bar */}
+      <div className="border-t border-gray-800">
+        <div className="max-w-6xl mx-auto px-4 py-4 flex flex-col md:flex-row items-center justify-between gap-2">
+          <p className="text-xs text-gray-500">
+            © 2026 Parampara. All rights reserved. Licensed under{" "}
+            <a
+              href="https://www.apache.org/licenses/LICENSE-2.0"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="hover:text-orange-400 transition-colors duration-200"
+            >
+              Apache 2.0
+            </a>
+            .
+          </p>
+          <p className="text-xs text-gray-500 italic">
+            "Enabling culture to thrive across borders."
+          </p>
+        </div>
+      </div>
+    </footer>
+  );
+}


### PR DESCRIPTION
- Contributing on behalf of NSoC'26

##  feat: Add Footer to Website

Closes #7

### Changes Made
- Created `components/Footer.tsx` with full branded footer
- 4-column layout: Brand column + Platform, Legal, Community links
- Apache 2.0 license + vision quote in bottom bar
- External links (GitHub, NSoC) open in new tab with ↗ indicator
- `body` updated to `flex flex-col min-h-screen` so footer always sticks to bottom
- `main` updated to `flex-1` to push footer down on short pages
- Fully responsive: stacks to single column on mobile

### Checklist
- [x] `components/Footer.tsx` created
- [x] Imported in `app/layout.tsx`
- [x] © 2026 Parampara copyright notice
- [x] Nav links: Home, Instructors, About, Terms, Privacy
- [x] NSoC '26 and GitHub external links
- [x] Mobile responsive (stacks vertically)
- [x] Footer sticks to bottom on short pages

@Mehren7 please reivew and please add as level3 because i just create the full footer with links of all attributes and having the proper alignment.