### PR TITLE
feat: restyle terms and privacy pages to match site violet/slate theme

### DIFF
--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -2,85 +2,78 @@ import type { Metadata } from "next";
 import Link from "next/link";
 
 export const metadata: Metadata = {
-  title: "Terms of Service",
+  title: "Privacy Policy",
   description:
-    "Terms of Service for Parampara — the cultural learning marketplace connecting diaspora with Indian women instructors.",
+    "Privacy Policy for Parampara — how we collect, use and protect your data.",
 };
 
 const sections = [
   {
-    id: "acceptance",
-    title: "Acceptance of Terms",
-    icon: "✅",
+    id: "information-collected",
+    title: "Information We Collect",
+    icon: "📋",
     content:
-      "By accessing or using Parampara, you agree to be bound by these Terms of Service and all applicable laws and regulations. If you do not agree with any of these terms, you are prohibited from using or accessing this platform. These terms apply to all users including learners, instructors, and visitors.",
+      "We collect information you provide directly: name, email address, and profile details when you register. We also collect usage data such as pages visited, session bookings made, and interactions with instructor profiles. Payment information is handled entirely by our third-party payment processors (Razorpay/Stripe) and is never stored on our servers.",
   },
   {
-    id: "use-of-platform",
-    title: "Use of Platform",
-    icon: "🌐",
+    id: "how-we-use",
+    title: "How We Use Your Data",
+    icon: "⚙️",
     content:
-      "Parampara is a cultural learning marketplace that facilitates live sessions between learners and instructors. You agree to use the platform only for lawful purposes. You must not misuse the platform by introducing malicious content, attempting unauthorized access, or engaging in any activity that disrupts the service for other users.",
+      "We use your data to provide and improve the Parampara platform, process session bookings, send booking confirmations and reminders, display your profile to relevant instructors or learners, and improve our recommendation algorithms. We do not use your data for advertising purposes.",
   },
   {
-    id: "instructor-responsibilities",
-    title: "Instructor Responsibilities",
-    icon: "👩‍🏫",
+    id: "data-sharing",
+    title: "Data Sharing",
+    icon: "🤝",
     content:
-      "Instructors on Parampara are independent individuals, not employees of Parampara. Instructors are responsible for the accuracy of their profile information, the quality of sessions they conduct, maintaining a respectful and professional environment, and complying with all applicable local laws regarding income and taxation.",
+      "We do not sell your personal data to third parties. We share data only with: instructors when you book their session (name and contact for coordination), payment processors to complete transactions, and service providers who help us operate the platform under strict confidentiality agreements.",
   },
   {
-    id: "learner-responsibilities",
-    title: "Learner Responsibilities",
-    icon: "📚",
+    id: "cookies",
+    title: "Cookies",
+    icon: "🍪",
     content:
-      "Learners are responsible for attending booked sessions on time, treating instructors with respect, providing honest and constructive feedback, and not recording or redistributing session content without the instructor's explicit consent.",
+      "Parampara uses essential cookies to keep you logged in and remember your preferences. We may use analytics cookies to understand how users navigate the platform and improve the experience. You can disable cookies in your browser settings, though some platform features may not work correctly without them.",
   },
   {
-    id: "payments",
-    title: "Payments & Refunds",
-    icon: "💳",
+    id: "your-rights",
+    title: "Your Rights",
+    icon: "✊",
     content:
-      "All payments on Parampara are processed securely via third-party payment gateways (Razorpay/Stripe). Refunds may be issued if a session is cancelled by the instructor or if a technical failure prevents the session from taking place. Refund requests must be raised within 48 hours of the scheduled session. Parampara reserves the right to modify its pricing and refund policies at any time.",
+      "You have the right to access the personal data we hold about you, request correction of inaccurate data, request deletion of your account and associated data, withdraw consent for data processing at any time, and lodge a complaint with a data protection authority. To exercise these rights, contact us via GitHub.",
   },
   {
-    id: "intellectual-property",
-    title: "Intellectual Property",
-    icon: "🔐",
+    id: "data-security",
+    title: "Data Security",
+    icon: "🛡️",
     content:
-      "All content on Parampara — including the platform design, logos, and written content — is the property of Parampara and protected under applicable intellectual property laws. Session content shared by instructors remains their intellectual property. Users may not reproduce or distribute platform content without prior written permission.",
+      "We implement industry-standard security measures to protect your data including HTTPS encryption for all data in transit, secure password hashing, and regular security audits. However, no system is 100% secure and we encourage you to use a strong, unique password for your Parampara account.",
   },
   {
-    id: "termination",
-    title: "Termination",
-    icon: "🚫",
+    id: "childrens-privacy",
+    title: "Children's Privacy",
+    icon: "👶",
     content:
-      "Parampara reserves the right to suspend or terminate any user account at its discretion if a user is found to be in violation of these Terms of Service, engaged in fraudulent activity, or behaving in a manner harmful to other users or the platform's reputation.",
+      "Parampara is not intended for children under the age of 13. We do not knowingly collect personal information from children. If you believe a child has provided us with personal information, please contact us immediately and we will delete it promptly.",
   },
   {
-    id: "liability",
-    title: "Limitation of Liability",
-    icon: "⚖️",
-    content:
-      "Parampara is provided on an 'as is' basis. We do not guarantee uninterrupted or error-free service. To the fullest extent permitted by law, Parampara shall not be liable for any indirect, incidental, or consequential damages arising from your use of the platform, including but not limited to loss of data, revenue, or goodwill.",
-  },
-  {
-    id: "changes",
-    title: "Changes to Terms",
+    id: "policy-changes",
+    title: "Changes to This Policy",
     icon: "🔄",
     content:
-      "Parampara reserves the right to update these Terms of Service at any time. Changes will be effective immediately upon posting to the platform. Continued use of the platform after any changes constitutes your acceptance of the new terms. We encourage users to review this page periodically.",
+      "We may update this Privacy Policy from time to time. When we do, we will update the 'Last updated' date at the top of this page. We encourage you to review this page periodically. Continued use of Parampara after any changes constitutes acceptance of the updated policy.",
   },
   {
     id: "contact",
     title: "Contact Us",
     icon: "💬",
     content:
-      "If you have any questions about these Terms of Service, please reach out to us through our GitHub repository. We are committed to resolving any concerns in a fair and timely manner.",
+      "If you have questions about this Privacy Policy or how we handle your data, please reach out via our GitHub repository. We are committed to addressing privacy concerns transparently and promptly.",
   },
 ];
 
-export default function TermsPage() {
+export default function PrivacyPage() {
   return (
     <main className="mx-auto max-w-7xl px-6 py-12 lg:px-8">
       {/* Hero */}
@@ -90,7 +83,7 @@ export default function TermsPage() {
             Home
           </Link>
           <span>/</span>
-          <span className="text-slate-800 font-medium">Terms of Service</span>
+          <span className="text-slate-800 font-medium">Privacy Policy</span>
         </div>
 
         <div className="flex flex-col lg:flex-row lg:items-end justify-between gap-6">
@@ -99,18 +92,17 @@ export default function TermsPage() {
               Legal
             </p>
             <h1 className="text-4xl font-semibold tracking-tight text-slate-950 sm:text-5xl mb-3">
-              Terms of Service
+              Privacy Policy
             </h1>
             <p className="text-slate-600">
               Last updated: <strong>April 2026</strong> · Effective immediately
-              upon use of the platform
             </p>
           </div>
           <Link
-            href="/privacy"
+            href="/terms"
             className="inline-flex items-center justify-center rounded-full border border-slate-200 bg-white px-6 py-3 text-base font-semibold text-slate-700 transition hover:bg-slate-50 whitespace-nowrap"
           >
-            View Privacy Policy →
+            View Terms of Service →
           </Link>
         </div>
       </section>
@@ -119,16 +111,15 @@ export default function TermsPage() {
       <section className="mb-12">
         <div className="rounded-[2rem] bg-violet-900 px-8 py-10 text-white shadow-2xl shadow-violet-600/20">
           <div className="flex gap-4 items-start">
-            <span className="text-3xl shrink-0">🌏</span>
+            <span className="text-3xl shrink-0">🔒</span>
             <div>
               <p className="text-sm font-semibold uppercase tracking-[0.24em] text-violet-300 mb-2">
-                Welcome to Parampara
+                Your Privacy Matters
               </p>
               <p className="text-lg leading-8 text-violet-200 max-w-3xl">
-                Please read these terms carefully before using the platform. By
-                using Parampara, you agree to these terms in full. These terms
-                govern your relationship with Parampara as a learner,
-                instructor, or visitor.
+                At Parampara, your privacy is deeply important to us. This
+                policy explains what data we collect, how we use it, and your
+                rights as a user of our cultural learning platform.
               </p>
             </div>
           </div>
@@ -187,7 +178,7 @@ export default function TermsPage() {
           {/* Bottom Note */}
           <div className="rounded-3xl border border-slate-200 bg-slate-50 p-8 text-center mt-4">
             <p className="text-slate-600">
-              These Terms were last reviewed in{" "}
+              This Privacy Policy was last reviewed in{" "}
               <strong className="text-slate-900">April 2026</strong>. Parampara
               is open-source under the{" "}
               <strong className="text-slate-900">Apache 2.0 License</strong>.
@@ -210,10 +201,11 @@ export default function TermsPage() {
         <div className="flex items-center justify-between gap-4 rounded-3xl border border-slate-200 bg-white p-8 shadow-sm">
           <div>
             <h2 className="text-2xl font-semibold text-slate-900">
-              Ready to get started?
+              Ready to begin?
             </h2>
             <p className="mt-2 text-slate-600">
-              Browse instructors and begin your cultural learning journey today.
+              Browse instructors and start your cultural learning journey rooted
+              in authentic Indian heritage.
             </p>
           </div>
           <Link

--- a/components/ScrollToTop.tsx
+++ b/components/ScrollToTop.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+export function ScrollToTop() {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const handleScroll = () => {
+      setVisible(window.scrollY > 300);
+    };
+    window.addEventListener("scroll", handleScroll);
+    return () => window.removeEventListener("scroll", handleScroll);
+  }, []);
+
+  const scrollToTop = () => {
+    window.scrollTo({ top: 0, behavior: "smooth" });
+  };
+
+  if (!visible) return null;
+
+  return (
+    <button
+      onClick={scrollToTop}
+      aria-label="Scroll to top"
+      className="fixed bottom-6 right-6 z-50 bg-orange-600 text-white w-10 h-10 rounded-full shadow-lg flex items-center justify-center hover:bg-orange-700 transition-colors duration-200"
+    >
+      ↑
+    </button>
+  );
+}


### PR DESCRIPTION
##  feat: Add Privacy Policy Page (`/privacy`) And Improve Style Of Terms Page

Closes #14

### Changes Made
- Created `app/privacy/page.tsx` at `/privacy` route
- Styled consistently with the site's violet/slate design system
  (matches homepage, terms page, and instructors page)
- Sticky sidebar with numbered table of contents (9 sections)
- Violet-900 intro banner with "Your Privacy Matters" messaging
- Each section rendered as an individual `rounded-3xl` card with
  violet numbered badge and icon
- Breadcrumb navigation (Home / Privacy Policy)
- Cross-link to Terms of Service page
- Bottom CTA section matching homepage "Ready to begin?" style
- Page-level SEO metadata exported

### Sections Covered
1. 📋 Information We Collect
2. ⚙️ How We Use Your Data
3. 🤝 Data Sharing
4. 🍪 Cookies
5. ✊ Your Rights
6. 🛡️ Data Security
7. 👶 Children's Privacy
8. 🔄 Changes to This Policy
9. 💬 Contact Us

### Checklist
- [x] `app/privacy/page.tsx` created
- [x] All key privacy sections covered
- [x] Consistent violet/slate styling matching site theme
- [x] Sticky sidebar table of contents
- [x] SEO metadata exported
- [x] Mobile responsive
- [x] Footer link navigates correctly to `/privacy`
- [x] Cross-link to `/terms` page

- Also fully changes the terms page style to match other page styles.

**Contributing on behalf of NSoC'26 **

@Mehren7 please review and please add as level3